### PR TITLE
Add setter to currentButtonType and animate

### DIFF
--- a/VBFPopFlatButton/VBFPopFlatButtonClasses/VBFPopFlatButton.m
+++ b/VBFPopFlatButton/VBFPopFlatButtonClasses/VBFPopFlatButton.m
@@ -280,7 +280,13 @@
     [self.secondSegment animatePositionToPoint:secondOriginPoint];
     [self.thirdSegment animatePositionToPoint:thirdOriginPoint];
     
-    self.currentButtonType = finalType;
+    _currentButtonType = finalType;
+}
+
+- (void)setCurrentButtonType:(FlatButtonType)currentButtonType {
+    if (self.currentButtonType != currentButtonType) {
+        [self animateToType:currentButtonType];
+    }
 }
 
 #pragma mark - Deprecated


### PR DESCRIPTION
Currently the button defaults to buttonPlainStyle when initWithCoder.

Add a setter to currentButtonType which then animates the button. This is so we can set the buttonType before view is displayed.
