### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Pods/pop/README.md
+++ b/Pods/pop/README.md
@@ -18,7 +18,7 @@ Alternatively, you can add the project to your workspace and adopt the provided 
 Pop adopts the Core Animation explicit animation programming model. Use by including the following import:
 
 ```objective-c
-#import <POP/POP.h>
+# import <POP/POP.h>
 ```
 
 ### Start, Stop & Update

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ And here you can see them animated:
 ![ButtonDribbble](https://d13yacurqjgara.cloudfront.net/users/381133/screenshots/1696580/vbfpopflatbutton3.gif)
 
 
-##How to use it
+## How to use it
 Best way is using CocoaPods
 
     pod 'VBFPopFlatButton'


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
